### PR TITLE
i7: persist events of interest in the repository

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -126,6 +126,23 @@ Replicator.prototype.init = function(initCallback) {
 				targetDb.bulk({docs:docs}, 
 							  function(err, data) {
 								if(err) {
+
+									// an error was returned; assume that none of the documents was successfully stored
+									this.stats.failed = this.stats.failed + batch.changes.length;
+
+									// save error information for troubleshooting purposes
+									rr.saveErrorEvent('target-bulk-write-error',
+													  'target database',
+													  {	
+													 	error: err	
+													  },
+											          function(err) {
+											          	if(err) {
+											         		console.error('"target-bulk-write-error" event data could not be saved in the repository: ' + err);
+											         	}
+											         	console.log('"target-bulk-write-error" event data was saved in the repository.');
+											          });
+
 									return callback('Error saving documents in target database "' + 
 													this.targetCredentials.dbname + '": ' + err);
 								}
@@ -151,6 +168,20 @@ Replicator.prototype.init = function(initCallback) {
 												this);
 
 									if(errors.length > 0) {
+
+										// save error information for troubleshooting purposes
+										rr.saveErrorEvent('target-bulk-write-error',
+														  'target database',
+														  {
+														  	results: data	
+														  },
+												          function(err) {
+												         	if(err) {
+												         		console.error('"target-bulk-write-error" event data could not be saved in the repository: ' + err);
+												         	}
+												         	console.log('"target-bulk-write-error" event data was saved in the repository.');
+												          });
+
 										return callback('Error saving documents in target database "' + 
 														this.targetCredentials.dbname + '": ' + JSON.stringify(errors));
 									}
@@ -170,7 +201,7 @@ Replicator.prototype.init = function(initCallback) {
 
 			// repository is not available
 			rr.on('error', function(message) {
-				return initCallback('Error. The repository database is not available: ' + message);		
+				return initCallback('Error. The repository is not available: ' + message);		
 			});
 
 			// repository is ready
@@ -197,30 +228,31 @@ Replicator.prototype.init = function(initCallback) {
 							           		  target: mutil.getCredentialsWithoutPassword(this.targetCredentials)}));
 
 						// save configuration information (informational purposes only)
-						rr.saveEvent('start',
-									 {source: mutil.getCredentialsWithoutPassword(this.sourceCredentials), 
-									  target: mutil.getCredentialsWithoutPassword(this.targetCredentials),
-									  filter: {
-									  	server: {
-									  		'name' : filter.getServerFilterName(), 
-									  		'definition': filter.getServerFilterDefinition()
-									  	}, 
-									  	client: {
-									  		'name' : filter.getClientFilterName(), 
-									  		'definition': filter.getClientFilterDefinition()
-									  	}
-									  },
-									  transformer: {
-									  		'name': transformer.getName(),
-									  		'definition': transformer.getRoutineDefinition()	
-									  }		  
-									 },
-							         function(err) {
-							         	if(err) {
-							         		console.error('Configuration information could not be saved in repository: ' + err);
-							         	}
-							         	console.error('Service configuration was recorded in the repository database');
-							         });
+						rr.saveInfoEvent('start',
+										 'application',
+										 {source: mutil.getCredentialsWithoutPassword(this.sourceCredentials), 
+										  target: mutil.getCredentialsWithoutPassword(this.targetCredentials),
+										  filter: {
+										  	server: {
+										  		'name' : filter.getServerFilterName(), 
+										  		'definition': filter.getServerFilterDefinition()
+										  	}, 
+										  	client: {
+										  		'name' : filter.getClientFilterName(), 
+										  		'definition': filter.getClientFilterDefinition()
+										  	}
+										  },
+										  transformer: {
+										  		'name': transformer.getName(),
+										  		'definition': transformer.getRoutineDefinition()	
+										  }		  
+										 },
+								         function(err) {
+								         	if(err) {
+								         		console.error('Configuration information could not be saved in repository: ' + err);
+								         	}
+								         	console.log('Service configuration was recorded in the repository.');
+								         });
 
 						var changes = [];
 						const changes_per_batch = 500;
@@ -300,35 +332,40 @@ Replicator.prototype.init = function(initCallback) {
 
 						// an error occurred while listening to the change feed
 						feed.on('error', function (error) {
-								rr.saveEvent('source_feed_error',
-											 JSON.stringify(error));
+								rr.saveErrorEvent('source_feed_error',
+												  'source feed',
+											 	  JSON.stringify(error));
 							  	console.error('Source feed error: ' + error);
 							   });
 
 						// TBD
 						feed.on('inactive', function (message) {
-								rr.saveEvent('source_feed_inactive',
-											 message);
+								rr.saveWarningEvent('source_feed_inactive',
+											 		'source feed',									
+											  		message);
 							  	console.log('Inactive: ' + message);
 							  	console.log('Pending: '+ changes.length);
 							   });
 
 						// a timeout occurred while listening to the change feed
 						feed.on('timeout', function (info) {
-								rr.saveEvent('source_feed_timeout',
-											 info);
+								rr.saveErrorEvent('source_feed_timeout',
+											 	  'source feed',									
+											 	  info);
 							   });
 
 						// an error occurred while listening to the change feed
 						feed.on('retry', function (info) {
-								rr.saveEvent('source_feed_retry',
-											 info);
+								rr.saveInfoEvent('source_feed_retry',
+												 'source feed',									
+											 	 info);
 							   });
 
 						// change feed is stopping (because of an error or stop())
 						feed.on('stop', function () {
-								rr.saveEvent('source_feed_stopped',
-											 null);
+								rr.saveInfoEvent('source_feed_stopped',
+											 	 'source feed',									
+											 	 null);
 							  	console.error('Source feed stopped.');
 							   });
 

--- a/lib/util/cloudantRepository.js
+++ b/lib/util/cloudantRepository.js
@@ -231,60 +231,6 @@ CloudantRepository.prototype.saveRecoveryInfo = function(last_update_seq,
  * @returns {Callback} callback - callback(err)
  * @returns {String} err - error message
  */
- /*
-CloudantRepository.prototype.saveEvent = function(event_type,
-												  source,
-												  severity,
-												  data,
-												  callback) {
-
-	if((! callback) || (typeof callback !== 'function')) {
-		callback = function(err) {
-			if(err) {
-				console.error('Callback in saveEvent is missing. Using default to display error: ' + err);
-			}
-		};
-	}
-
-	if((! this.state) || (this.state === 'error')) {
-		return callback('The repository database is not ready.');
-	}
-
-	var eventRecord = {
-						task_id: this.taskId,
-						record_type: 'event',
-						source: source,
-						severity: severity,
-						event_type: event_type,
-						data: data,
-						timestamp: new Date().toISOString()
-					  };
-
-	debug('Saving source feed event: ' + JSON.stringify(eventRecord));				  
-
-	this.repositoryDb.insert(eventRecord, function(err) {
-		if(err) {
-			console.error('Event record write failure FFDC: ' + JSON.stringify(eventRecord));
-			return callback('Event record could not be saved: ' + JSON.stringify(err));
-		}
-		else {
-			return callback();
-		}
-	});							
-
-};
-*/
-
-
-/*
- * Saves event information in the repository.
- * @param {String} event - name of the event 
- * @param {String} source - identifies the entity that caused this event
- * @param {String} severity - one of i[nformational], w[arning], e[rror], f[atal]
- * @param {String} data - data associated with the event
- * @returns {Callback} callback - callback(err)
- * @returns {String} err - error message
- */
 CloudantRepository.prototype.saveEvent = function(event_type,
 												  severity,
 											      source,

--- a/lib/util/cloudantRepository.js
+++ b/lib/util/cloudantRepository.js
@@ -78,6 +78,12 @@ function CloudantRepository(cloudantRepository,
 								    		events: {
 								      			map: 'function (doc) {\n  if((doc.record_type) && (doc.record_type === \'event\')) {\n    emit(doc.task_id, [doc.event_type, doc.timestamp]);\n  }\n}'
 								    		},
+											target_database_events: {
+								      			map: 'function (doc) {\n  if((doc.record_type) && (doc.record_type === \'event\') && (doc.source === \'target database\')) {\n    emit(doc.task_id, [doc.event_type, doc.timestamp]);\n  }\n}'
+								    		},
+											application_events: {
+								      			map: 'function (doc) {\n  if((doc.record_type) && (doc.record_type === \'event\') && (doc.source === \'application\')) {\n    emit(doc.task_id, [doc.event_type, doc.timestamp]);\n  }\n}'
+								    		},								    										    										    		
 								    		recovery: {
 								      			map: 'function (doc) {\n  if((doc.record_type) && (doc.record_type === \'recovery\')) {\n    emit(doc._id, [doc.last_update_seq.split(\'-\')[0],doc.last_change_applied]);\n  }\n}'
 								    		}
@@ -91,7 +97,7 @@ function CloudantRepository(cloudantRepository,
 											 function(err) {
 												if(err) {
 													// treat as non-fatal error
-													debug('Could ot create design document in repository database: ' + err);
+													console.error('Could ot create design document in repository database: ' + err);
 												}
 												this.state = 'ready';
 												debug('Repository database was initialized.');
@@ -218,12 +224,17 @@ CloudantRepository.prototype.saveRecoveryInfo = function(last_update_seq,
 
 /*
  * Saves event information in the repository.
- * @param {String} event - name of the event  
+ * @param {String} event - name of the event 
+ * @param {String} source - identifies the entity that caused this event
+ * @param {String} severity - one of i[nformational], w[arning], e[rror], f[atal]
  * @param {String} data - data associated with the event
  * @returns {Callback} callback - callback(err)
  * @returns {String} err - error message
  */
+ /*
 CloudantRepository.prototype.saveEvent = function(event_type,
+												  source,
+												  severity,
 												  data,
 												  callback) {
 
@@ -242,6 +253,8 @@ CloudantRepository.prototype.saveEvent = function(event_type,
 	var eventRecord = {
 						task_id: this.taskId,
 						record_type: 'event',
+						source: source,
+						severity: severity,
 						event_type: event_type,
 						data: data,
 						timestamp: new Date().toISOString()
@@ -251,6 +264,7 @@ CloudantRepository.prototype.saveEvent = function(event_type,
 
 	this.repositoryDb.insert(eventRecord, function(err) {
 		if(err) {
+			console.error('Event record write failure FFDC: ' + JSON.stringify(eventRecord));
 			return callback('Event record could not be saved: ' + JSON.stringify(err));
 		}
 		else {
@@ -258,6 +272,118 @@ CloudantRepository.prototype.saveEvent = function(event_type,
 		}
 	});							
 
+};
+*/
+
+
+/*
+ * Saves event information in the repository.
+ * @param {String} event - name of the event 
+ * @param {String} source - identifies the entity that caused this event
+ * @param {String} severity - one of i[nformational], w[arning], e[rror], f[atal]
+ * @param {String} data - data associated with the event
+ * @returns {Callback} callback - callback(err)
+ * @returns {String} err - error message
+ */
+CloudantRepository.prototype.saveEvent = function(event_type,
+												  severity,
+											      source,
+												  data,
+												  callback) {
+
+	if((! callback) || (typeof callback !== 'function')) {
+		callback = function(err) {
+			if(err) {
+				console.error('Callback in saveEvent is missing. Using default to display error: ' + err);
+			}
+		};
+	}
+
+	if((! this.state) || (this.state === 'error')) {
+		return callback('The repository database is not ready.');
+	}
+
+	var eventRecord = {
+						task_id: this.taskId,
+						record_type: 'event',
+						source: source,
+						severity: severity,
+						event_type: event_type,
+						data: data,
+						timestamp: new Date().toISOString()
+					  };
+
+	debug('Saving source feed event: ' + JSON.stringify(eventRecord));				  
+
+	this.repositoryDb.insert(eventRecord, function(err) {
+		if(err) {
+			console.error('Event record write failure FFDC: ' + JSON.stringify(eventRecord));
+			return callback('Event record could not be saved: ' + JSON.stringify(err));
+		}
+		else {
+			return callback();
+		}
+	});							
+
+};
+
+/*
+ * Saves an informational warning event in the repository.
+ * @param {String} event - name of the event 
+ * @param {String} source - identifies the entity that caused this event
+ * @param {String} data - data associated with the event
+ * @returns {Callback} callback - callback(err)
+ * @returns {String} err - error message
+ */
+CloudantRepository.prototype.saveInfoEvent = function(event_type,
+													  source,
+													  data,
+													  callback) {
+	this.saveEvent(event_type,
+				   'info',
+				   source,
+				   data,
+				   callback);
+
+};
+
+/*
+ * Saves a warning event in the repository.
+ * @param {String} event - name of the event 
+ * @param {String} source - identifies the entity that caused this event
+ * @param {String} data - data associated with the event
+ * @returns {Callback} callback - callback(err)
+ * @returns {String} err - error message
+ */
+CloudantRepository.prototype.saveWarningEvent = function(event_type,
+													     source,
+													     data,
+													     callback) {
+	this.saveEvent(event_type,
+				   'warn',
+				   source,
+				   data,
+				   callback);
+};
+
+
+/*
+ * Saves an error event in the repository.
+ * @param {String} event - name of the event 
+ * @param {String} source - identifies the entity that caused this event
+ * @param {String} data - data associated with the event
+ * @returns {Callback} callback - callback(err)
+ * @returns {String} err - error message
+ */
+CloudantRepository.prototype.saveErrorEvent = function(event_type,
+													   source,
+													   data,
+													   callback) {
+	this.saveEvent(event_type,
+				   'error',
+				   source,
+				   data,
+				   callback);
 };
 
 // export constructor


### PR DESCRIPTION
- Added additional views to `_design/repository` design doc in the repository database:
  - `target_database_events`: events related to operations against the target database (e.g. bulk write)
  - `application_events`:  general events, unrelated to operations performed against the source database or the target database 
- Added new methods to save events using `info`, `warn` or `error` severity.
